### PR TITLE
fix: update module path from v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stuttgart-things/homerun-library/v2
+module github.com/stuttgart-things/homerun-library/v3
 
 go 1.24.0
 
@@ -6,7 +6,6 @@ toolchain go1.26.1
 
 require (
 	github.com/RediSearch/redisearch-go v1.1.1
-	github.com/RediSearch/redisearch-go/v2 v2.1.1
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/nitishm/go-rejson/v4 v4.2.0

--- a/tests/helpers/pick_random.go
+++ b/tests/helpers/pick_random.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	homerun "github.com/stuttgart-things/homerun-library/v2" // use module path from go.mod
+	homerun "github.com/stuttgart-things/homerun-library/v3" // use module path from go.mod
 )
 
 func main() {

--- a/tests/pitcher/pitch_message.go
+++ b/tests/pitcher/pitch_message.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	homerun "github.com/stuttgart-things/homerun-library/v2" // use module path from go.mod
+	homerun "github.com/stuttgart-things/homerun-library/v3" // use module path from go.mod
 )
 
 func main() {

--- a/tests/table/print_demo.go
+++ b/tests/table/print_demo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jedib0t/go-pretty/v6/table"
-	homerun "github.com/stuttgart-things/homerun-library/v2" // use module path from go.mod
+	homerun "github.com/stuttgart-things/homerun-library/v3" // use module path from go.mod
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Updates Go module path from `homerun-library/v2` to `homerun-library/v3` to match semver tags
- The v3.x tags (v3.0.0-v3.0.3) were released with `/v2` module path, breaking Go module resolution
- Updates all internal import paths in tests/

## Note
After this merges and releases as v3.0.4+, consumers can properly import `homerun-library/v3`.
The old v3.0.0-v3.0.3 tags remain broken — consider deleting them after the new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)