### PR TITLE
feat: per-call Redis stream override for EnqueueMessageInRedisStreams

### DIFF
--- a/pitcher.go
+++ b/pitcher.go
@@ -88,9 +88,15 @@ var (
 //			Stream:   "messages",
 //		},
 //	)
+//
+// The optional variadic streamOverride parameter, if set and non-empty, publishes
+// to that stream instead of rc.Stream. Only the first value is used. This lets a
+// single process route messages to different streams without mutating shared
+// RedisConfig.
 func EnqueueMessageInRedisStreams(
 	msg Message,
 	rc RedisConfig,
+	streamOverride ...string,
 ) (objectID, streamID string, err error) {
 
 	redisJSONHandler := rejson.NewReJSONHandler()
@@ -108,7 +114,7 @@ func EnqueueMessageInRedisStreams(
 	}
 
 	// Enqueue object reference in Redis Stream
-	streamID = rc.Stream
+	streamID = resolveStream(rc, streamOverride...)
 	streamValues := map[string]interface{}{
 		"messageID": objectID,
 	}
@@ -134,4 +140,19 @@ func EnqueueMessageInRedisStreams(
 	)
 
 	return objectID, streamID, nil
+}
+
+// resolveStream picks the effective stream name: the first non-empty streamOverride
+// wins, otherwise rc.Stream. Extra override entries are ignored (a warning is logged).
+func resolveStream(rc RedisConfig, streamOverride ...string) string {
+	if len(streamOverride) > 1 {
+		logger.Warn(
+			"EnqueueMessageInRedisStreams received multiple streamOverride values; using the first",
+			logger.Args("count", len(streamOverride)),
+		)
+	}
+	if len(streamOverride) > 0 && streamOverride[0] != "" {
+		return streamOverride[0]
+	}
+	return rc.Stream
 }

--- a/pitcher_test.go
+++ b/pitcher_test.go
@@ -1,0 +1,27 @@
+package homerun
+
+import "testing"
+
+func TestResolveStream(t *testing.T) {
+	rc := RedisConfig{Stream: "default-stream"}
+
+	tests := []struct {
+		name     string
+		override []string
+		want     string
+	}{
+		{"no override uses rc.Stream", nil, "default-stream"},
+		{"non-empty override wins", []string{"releases"}, "releases"},
+		{"empty-string override falls back", []string{""}, "default-stream"},
+		{"multiple overrides use the first", []string{"first", "second"}, "first"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveStream(rc, tt.override...)
+			if got != tt.want {
+				t.Errorf("resolveStream(%v) = %q, want %q", tt.override, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #84
Refs #83

## Summary

- Adds an optional trailing variadic `streamOverride ...string` parameter to `EnqueueMessageInRedisStreams`.
- First non-empty override wins; otherwise falls back to `rc.Stream` (existing behavior).
- Extra override values are ignored with a warning log (defensive — likely a caller bug).
- Purely additive: all existing call sites compile and behave unchanged.

## Why

Unblocks per-source stream routing in producers so a single process can publish different events to different streams without mutating a shared `RedisConfig`. Primary motivating use case: stuttgart-things/homerun2-git-pitcher#14 (per-repo stream override in the git watcher).

See the tracking ticket #83 for the full cross-service rollout plan.

## Changes

- `pitcher.go`: variadic param + small `resolveStream()` helper
- `pitcher_test.go` (new): table-driven unit test covering the four resolution cases — no Redis required

## Test plan

- [x] `go build ./...`
- [x] `go test -run TestResolveStream ./...` — 4/4 subtests pass
- [x] Existing `TestEnqueueMessageInRedisStreams` compiles without edits (back-compat)
- [ ] CI green