### PR TITLE
docs: fix stale v2 references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Shared Go library module for the **homerun** microservice family.
 
-[![Dagger Static Checks](https://github.com/stuttgart-things/homerun-library/v2/actions/workflows/dagger-static-checks.yaml/badge.svg)](https://github.com/stuttgart-things/homerun-library/v2/actions/workflows/dagger-static-checks.yaml)
-[![Dagger Tests](https://github.com/stuttgart-things/homerun-library/v2/actions/workflows/dagger-tests.yaml/badge.svg)](https://github.com/stuttgart-things/homerun-library/v2/actions/workflows/dagger-tests.yaml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/stuttgart-things/homerun-library/v2.svg)](https://pkg.go.dev/github.com/stuttgart-things/homerun-library/v2)
+[![Dagger Static Checks](https://github.com/stuttgart-things/homerun-library/actions/workflows/dagger-static-checks.yaml/badge.svg)](https://github.com/stuttgart-things/homerun-library/actions/workflows/dagger-static-checks.yaml)
+[![Dagger Tests](https://github.com/stuttgart-things/homerun-library/actions/workflows/dagger-tests.yaml/badge.svg)](https://github.com/stuttgart-things/homerun-library/actions/workflows/dagger-tests.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/stuttgart-things/homerun-library/v3.svg)](https://pkg.go.dev/github.com/stuttgart-things/homerun-library/v3)
 
 ## Features
 
@@ -20,7 +20,7 @@ Shared Go library module for the **homerun** microservice family.
 ## Installation
 
 ```bash
-go get github.com/stuttgart-things/homerun-library/v2
+go get github.com/stuttgart-things/homerun-library/v3
 ```
 
 ## Usage
@@ -33,7 +33,7 @@ package main
 import (
     "fmt"
     "time"
-    homerun "github.com/stuttgart-things/homerun-library/v2/v2"
+    homerun "github.com/stuttgart-things/homerun-library/v3"
 )
 
 func main() {


### PR DESCRIPTION
Badges, \`go get\` command, and import example in README.md still pointed at \`/v2\` after the v2→v3 module path bump in #78. This updates all of them to \`/v3\`.

Drive-by: the import example had a typo (\`/v2/v2\`) — now correct as \`/v3\`.

Pure docs change, no CI impact.